### PR TITLE
Refactor QuantumState::get_state

### DIFF
--- a/src/boolean_circuits/arithmetic.rs
+++ b/src/boolean_circuits/arithmetic.rs
@@ -395,7 +395,7 @@ mod arithmetic_tests {
                     .map(|m| measurements.get_measurement(m).unwrap().0)
                     .collect();
                 let state_index = state
-                    .get_state(true)
+                    .into_state(pipeline::Order::Natural)
                     .into_iter()
                     .position(|v| v == Complex::one())
                     .unwrap() as u64;

--- a/src/macros/inverter.rs
+++ b/src/macros/inverter.rs
@@ -220,7 +220,7 @@ fn remap_indices(op: UnitaryOp, new_indices: &[u64]) -> UnitaryOp {
 mod inverter_test {
     use super::*;
     use crate::boolean_circuits::arithmetic::{add, add_op};
-    use crate::pipeline::{get_required_state_size_from_frontier, InitialState};
+    use crate::pipeline::{get_required_state_size_from_frontier, InitialState, Order};
     use crate::utils::flip_bits;
     use crate::{run_debug, run_local_with_init, Complex, QuantumState};
     use num::One;
@@ -244,7 +244,7 @@ mod inverter_test {
                 run_local_with_init::<f64>(&r, &[(indices.clone(), InitialState::Index(indx))])
                     .unwrap();
             let pos = state
-                .get_state(false)
+                .into_state(Order::Unnatural)
                 .into_iter()
                 .position(|v| v == Complex::one())
                 .map(|pos| flip_bits(n as usize, pos as u64));

--- a/src/pipeline_debug.rs
+++ b/src/pipeline_debug.rs
@@ -1,7 +1,7 @@
 use crate::errors::CircuitError;
 use crate::measurement_ops::MeasuredCondition;
 use crate::pipeline::{
-    get_required_state_size_from_frontier, run_with_statebuilder, InitialState, QuantumState,
+    get_required_state_size_from_frontier, run_with_statebuilder, InitialState, QuantumState, Order,
 };
 use crate::state_ops::{get_index, num_indices, UnitaryOp};
 use crate::{Complex, Precision, Register};
@@ -158,7 +158,7 @@ impl<P: Precision> QuantumState<P> for PrintPipeline<P> {
         vec![]
     }
 
-    fn get_state(self, _: bool) -> Vec<Complex<P>> {
+    fn into_state(self, _: Order) -> Vec<Complex<P>> {
         vec![]
     }
 }

--- a/src/sparse_state/state.rs
+++ b/src/sparse_state/state.rs
@@ -1,6 +1,6 @@
 use crate::iterators::{fold_for_op_cols, precision_get_index, precision_num_indices};
 use crate::measurement_ops::MeasuredCondition;
-use crate::pipeline::{create_state_entry, InitialState};
+use crate::pipeline::{create_state_entry, InitialState, Order};
 use crate::sparse_state::utils::{
     consolidate_vec, sparse_measure, sparse_measure_prob, sparse_measure_probs, sparse_soft_measure,
 };
@@ -184,15 +184,14 @@ impl<P: Precision> QuantumState<P> for SparseQuantumState<P> {
         probs
     }
 
-    fn get_state(self, natural_order: bool) -> Vec<Complex<P>> {
+    fn into_state(self, order: Order) -> Vec<Complex<P>> {
         let mut state = vec![];
         let n = self.n as usize;
         state.resize(1 << n, Complex::zero());
         self.state.unwrap().into_iter().for_each(|(indx, val)| {
-            let indx = if natural_order {
-                flip_bits(n, indx)
-            } else {
-                indx
+            let indx = match order {
+                Order::Natural => flip_bits(n, indx),
+                Order::Unnatural => indx,
             };
             state[indx as usize] = val;
         });

--- a/src/trace_state/state.rs
+++ b/src/trace_state/state.rs
@@ -1,5 +1,5 @@
 use crate::measurement_ops::MeasuredCondition;
-use crate::pipeline::InitialState;
+use crate::pipeline::{InitialState, Order};
 use crate::sparse_state::SparseQuantumState;
 use crate::state_ops::UnitaryOp;
 use crate::utils::flip_bits;
@@ -77,7 +77,7 @@ impl<P: Precision> QuantumState<P> for TraceState<P> {
         self.state.stochastic_measure(indices, angle)
     }
 
-    fn get_state(self, natural_order: bool) -> Vec<Complex<P>> {
-        self.state.get_state(natural_order)
+    fn into_state(self, order: Order) -> Vec<Complex<P>> {
+        self.state.into_state(order)
     }
 }


### PR DESCRIPTION
(breaking change)

`into_xxx` is idiomatic way of showing that it consumes `self`.
Boolean arguments are also an anti-pattern, since it's not clear what they mean at the invocation spot.
Naming of `Order` and its variants likely needs to be changed to something better - suggestions welcome!