### PR TITLE
Add utils to tests

### DIFF
--- a/tests/basis_measure.rs
+++ b/tests/basis_measure.rs
@@ -1,14 +1,10 @@
 extern crate num;
 extern crate qip;
 
-use qip::*;
+mod utils;
 
-fn assert_almost_eq(a: f64, b: f64, prec: i32) {
-    let mult = 10.0f64.powi(prec);
-    let (a, b) = (a * mult, b * mult);
-    let (a, b) = (a.round(), b.round());
-    assert_eq!(a / mult, b / mult);
-}
+use qip::*;
+use utils::assert_almost_eq;
 
 #[test]
 fn test_measure_true() -> Result<(), CircuitError> {

--- a/tests/cswap_test.rs
+++ b/tests/cswap_test.rs
@@ -1,16 +1,12 @@
 extern crate num;
 extern crate qip;
 
+mod utils;
+
 use qip::pipeline::MeasurementHandle;
 use qip::qubits::RegisterHandle;
 use qip::*;
-
-fn assert_almost_eq(a: f64, b: f64, prec: i32) {
-    let mult = 10.0f64.powi(prec);
-    let (a, b) = (a * mult, b * mult);
-    let (a, b) = (a.round(), b.round());
-    assert_eq!(a / mult, b / mult);
-}
+use utils::assert_almost_eq;
 
 fn setup_cswap_circuit(
     vec_n: u64,

--- a/tests/sidechannel_tests.rs
+++ b/tests/sidechannel_tests.rs
@@ -1,14 +1,11 @@
 extern crate qip;
+
+mod utils;
+
 use qip::pipeline::MeasurementHandle;
 use qip::qubits::RegisterHandle;
 use qip::*;
-
-fn assert_almost_eq(a: f64, b: f64, prec: i32) {
-    let mult = 10.0f64.powi(prec);
-    let (a, b) = (a * mult, b * mult);
-    let (a, b) = (a.round(), b.round());
-    assert_eq!(a / mult, b / mult);
-}
+use utils::assert_almost_eq;
 
 fn setup_cswap_sidechannel_circuit(
     vec_n: u64,

--- a/tests/teleport_test.rs
+++ b/tests/teleport_test.rs
@@ -1,8 +1,12 @@
 extern crate qip;
+
+mod utils;
+
 use qip::common_circuits::epr_pair;
 use qip::errors::CircuitError;
 use qip::pipeline::MeasurementHandle;
 use qip::*;
+use utils::assert_almost_eq;
 
 fn run_alice(b: &mut OpBuilder, epr_alice: Register, initial_angle: f64) -> MeasurementHandle {
     // Set up the qubits
@@ -54,13 +58,6 @@ fn run_bob(
     // ps[1] = sin(theta)^2
     // theta = atan(sqrt(ps[1]/ps[0]))
     Ok(ps[1].sqrt().atan2(ps[0].sqrt()))
-}
-
-fn assert_almost_eq(a: f64, b: f64, prec: i32) {
-    let mult = 10.0f64.powi(prec);
-    let (a, b) = (a * mult, b * mult);
-    let (a, b) = (a.round(), b.round());
-    assert_eq!(a / mult, b / mult);
 }
 
 #[test]

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,0 +1,10 @@
+/// Utility functions for testing.
+
+/// Check if a decimal number is almost equal to another given
+/// precision.
+pub fn assert_almost_eq(a: f64, b: f64, prec: i32) {
+    let mult = 10.0f64.powi(prec);
+    let (a, b) = (a * mult, b * mult);
+    let (a, b) = (a.round(), b.round());
+    assert_eq!(a / mult, b / mult);
+}


### PR DESCRIPTION
The `assert_almost_eq` is duplicated in almost all the tests so i moved it into a new `utils` mod.