### PR TITLE
Examples PR 1: dense_coding, bell_inequalities, cswap

### DIFF
--- a/qip/examples/bell_inequalities.rs
+++ b/qip/examples/bell_inequalities.rs
@@ -1,68 +1,66 @@
 #[cfg(feature = "macros")]
 use qip::prelude::*;
+use qip::prelude::{CircuitBuilder, CircuitError};
 #[cfg(feature = "macros")]
 use qip_macros::*;
 #[cfg(feature = "macros")]
 use std::num::NonZeroUsize;
 
 #[cfg(feature = "macros")]
-fn circuit1() -> Vec<f64> {
+fn circuit1() -> Result<Vec<f64>, CircuitError>{
     let mut b = LocalBuilder::<f64>::default();
     let n = NonZeroUsize::new(2).unwrap();
 
     let q = b.qubit();
     let ra = b.register(n);
-    let r = program!(&mut b, r;
+    let r = program!(&mut b; r;
         not r;
         h r[0];
         control not r[0], r[1];
         rz(std::f64::consts::FRAC_PI_3) r[1];
         h r;
-    )
-    .unwrap();
-    let (r, m_handle) = b.stochastic_measure(r);
+    )?;
+    let (r, m_handle) = b.measure_stochastic(r);
 
     //run and get probabilities
     let (_, mut measured) = run_local::<f64>(&r).unwrap();
     measured.pop_stochastic_measurements(m_handle).unwrap()
 }
 
-#[cfg(feature = "macros")]
-fn circuit2() -> Vec<f64> {
+// #[cfg(feature = "macros")]
+fn circuit2() -> Result<Vec<f64>, CircuitError>{
     let mut b = LocalBuilder::<f64>::default();
     let n = NonZeroUsize::new(2).unwrap();
 
     let r = b.register(n);
-    let r = program!( &mut b, r;
+    let r = program!( &mut b; r;
         not r;
         h r[0];
         control not r[0], r[1];
         rz(2. * std::f64::consts::FRAC_PI_3) r[1];
         h r;
-    )
-    .unwrap();
-    let (r, m_handle) = b.stochastic_measure(r);
+    )?;
+    let (r, m_handle) = b.measure_stochastic(r);
 
     // run and get probabilities
     let (_, mut measured) = run_local::<f64>(&r).unwrap();
     measured.pop_stochastic_measurements(m_handle).unwrap()
 }
-#[cfg(feature = "macros")]
-fn circuit3() -> Vec<f64> {
+// #[cfg(feature = "macros")]
+fn circuit3() -> Result<Vec<f64>, CircuitError> {
     let mut b = LocalBuilder::<f64>::default();
     let n = NonZeroUsize::new(2).unwrap();
     let r = b.register(n);
 
-    let r = program!(&mut b, r;
+    let r = program!(&mut b; r;
         not r;
         h r[0];
         control not r[0], r[1];
         rz(std::f64::consts::FRAC_PI_3) r[0];
         rz(2. * std::f64::consts::FRAC_PI_3) r[1];
         h r;
-    )
-    .unwrap();
-    let (r, m_handle) = b.stochastic_measure(r);
+    )?;
+    let (r, m_handle) = b.measure_stochastic(r);
 
     // run and get probabilities
     let (_, mut measured) = run_local::<f64>(&r).unwrap();
@@ -78,23 +76,23 @@ fn main() -> () {}
 /// https://arxiv.org/pdf/1712.05642.pdf - II.IMPLEMENTED EXPERIMENTS -> 3. Bell's inequality
 ///
 /// A violation of the inequality is expected in any quantum computer or simulator.
-#[cfg(feature = "macros")]
+// #[cfg(feature = "macros")]
 fn main() -> Result<(), CircuitError> {
     println!("Bell inequality: |P(a, b) - P(a, c)| - P(b, c) <= 1");
 
     let a_b = circuit1();
-    let p_of_a_b = (a_b[0] + a_b[3]) - (a_b[1] + a_b[2]);
+    let p_of_a_b = (a_b?[0] + a_b?[3]) - (a_b?[1] + a_b?[2]);
     println!("P(a, b) = {:.2}", p_of_a_b);
 
     let a_c = circuit2();
-    let p_of_a_c = (a_c[0] + a_c[3]) - (a_c[1] + a_c[2]);
+    let p_of_a_c = (a_c?[0] + a_c?[3]) - (a_c?[1] + a_c?[2]);
     println!("P(a, c) = {:.2}", p_of_a_c);
 
     let b_c = circuit3();
-    let p_of_b_c = (b_c[0] + b_c[3]) - (b_c[1] + b_c[2]);
+    let p_of_b_c = (b_c?[0] + b_c?[3]) - (b_c?[1] + b_c?[2]);
     println!("P(b, c) = {:.2}", p_of_b_c);
 
-    let left_side = num::abs(p_of_a_b - p_of_a_c) - p_of_b_c;
+    let left_side = (p_of_a_b - p_of_a_c).abs() - p_of_b_c;
     println!(
         "|{:.2} - {:.2}| - ({:.2}) = {:.2} IS NOT <= 1",
         p_of_a_b, p_of_a_c, p_of_b_c, left_side

--- a/qip/examples/bell_inequalities.rs
+++ b/qip/examples/bell_inequalities.rs
@@ -1,12 +1,32 @@
 use qip::prelude::*;
+#[cfg(feature = "macros")]
+use qip_macros::*;
 use std::num::NonZeroUsize;
 
+#[cfg(feature = "macros")]
 fn circuit1() -> Vec<f64> {
-
     let mut b = LocalBuilder::<f64>::default();
     let n = NonZeroUsize::new(2).unwrap();
 
     let q = b.qubit();
     let ra = b.register(n);
-    let r = program!() //Not sure what to use here
+    let r = program!(&mut b, r;
+        not r;
+        h r[0];
+        control not r[0], r[1];
+        rz(std::f64::consts::FRAC_PI_3) r[1];
+        h r;
+    )
+    .unwrap();
+    let (r, m_handle) = b.stochastic_measure(r);
+
+    //run and get probabilities
+    let (_, mut measured) = run_local::<f64>(&r).unwrap();
+    measured.pop_stochastic_measurements(m_handle).unwrap()
 }
+
+
+
+#[cfg(not(feature = "macros"))]
+fn main() {}
+

--- a/qip/examples/bell_inequalities.rs
+++ b/qip/examples/bell_inequalities.rs
@@ -1,9 +1,11 @@
 #[cfg(feature = "macros")]
 use qip::prelude::*;
+#[cfg(feature = "macros")]
 use qip::prelude::{CircuitBuilder, CircuitError};
 #[cfg(feature = "macros")]
 use qip_macros::*;
 #[cfg(feature = "macros")]
+use qip::macros::program_ops::*;
 use std::num::NonZeroUsize;
 
 #[cfg(feature = "macros")]
@@ -27,7 +29,7 @@ fn circuit1() -> Result<Vec<f64>, CircuitError>{
     measured.pop_stochastic_measurements(m_handle).unwrap()
 }
 
-// #[cfg(feature = "macros")]
+#[cfg(feature = "macros")]
 fn circuit2() -> Result<Vec<f64>, CircuitError>{
     let mut b = LocalBuilder::<f64>::default();
     let n = NonZeroUsize::new(2).unwrap();
@@ -59,12 +61,10 @@ fn circuit3() -> Result<Vec<f64>, CircuitError> {
         rz(std::f64::consts::FRAC_PI_3) r[0];
         rz(2. * std::f64::consts::FRAC_PI_3) r[1];
         h r;
-    )?;
-    let (r, m_handle) = b.measure_stochastic(r);
-
-    // run and get probabilities
-    let (_, mut measured) = run_local::<f64>(&r).unwrap();
-    measured.pop_stochastic_measurements(m_handle).unwrap()
+    ).unwrap();
+    let (r, m_handle) = b.measure_stochastic(r); //returns (Self::Register, Self::StochasticMeasurementHandle)
+    let (_, measurements) = b.calculate_state();
+    let (m, _) = measurements.get_measurement(m_handle);
 }
 
 #[cfg(not(feature = "macros"))]
@@ -76,7 +76,7 @@ fn main() -> () {}
 /// https://arxiv.org/pdf/1712.05642.pdf - II.IMPLEMENTED EXPERIMENTS -> 3. Bell's inequality
 ///
 /// A violation of the inequality is expected in any quantum computer or simulator.
-// #[cfg(feature = "macros")]
+#[cfg(feature = "macros")]
 fn main() -> Result<(), CircuitError> {
     println!("Bell inequality: |P(a, b) - P(a, c)| - P(b, c) <= 1");
 

--- a/qip/examples/bell_inequalities.rs
+++ b/qip/examples/bell_inequalities.rs
@@ -64,7 +64,7 @@ fn circuit3() -> Result<Vec<f64>, CircuitError> {
     ).unwrap();
     let (r, m_handle) = b.measure_stochastic(r); //returns (Self::Register, Self::StochasticMeasurementHandle)
     let (_, measurements) = b.calculate_state();
-    let (m, _) = measurements.get_measurement(m_handle);
+    let (m, _) = measurements.get_stochastic_measurement(m_handle);
 }
 
 #[cfg(not(feature = "macros"))]

--- a/qip/examples/bell_inequalities.rs
+++ b/qip/examples/bell_inequalities.rs
@@ -1,3 +1,4 @@
+use qip::builder::StochasticMeasurementHandle;
 #[cfg(feature = "macros")]
 use qip::prelude::*;
 #[cfg(feature = "macros")]
@@ -49,7 +50,7 @@ fn circuit2() -> Result<Vec<f64>, CircuitError>{
     measured.pop_stochastic_measurements(m_handle).unwrap()
 }
 // #[cfg(feature = "macros")]
-fn circuit3() -> Result<Vec<f64>, CircuitError> {
+fn circuit3() {
     let mut b = LocalBuilder::<f64>::default();
     let n = NonZeroUsize::new(2).unwrap();
     let r = b.register(n);
@@ -64,7 +65,7 @@ fn circuit3() -> Result<Vec<f64>, CircuitError> {
     ).unwrap();
     let (r, m_handle) = b.measure_stochastic(r); //returns (Self::Register, Self::StochasticMeasurementHandle)
     let (_, measurements) = b.calculate_state();
-    let (m, _) = measurements.get_stochastic_measurement(m_handle);
+    let stochastic_measurement_probability = measurements.get_stochastic_measurement(m_handle);
 }
 
 #[cfg(not(feature = "macros"))]

--- a/qip/examples/bell_inequalities.rs
+++ b/qip/examples/bell_inequalities.rs
@@ -1,6 +1,8 @@
+#[cfg(feature = "macros")]
 use qip::prelude::*;
 #[cfg(feature = "macros")]
 use qip_macros::*;
+#[cfg(feature = "macros")]
 use std::num::NonZeroUsize;
 
 #[cfg(feature = "macros")]
@@ -25,8 +27,80 @@ fn circuit1() -> Vec<f64> {
     measured.pop_stochastic_measurements(m_handle).unwrap()
 }
 
+#[cfg(feature = "macros")]
+fn circuit2() -> Vec<f64> {
+    let mut b = LocalBuilder::<f64>::default();
+    let n = NonZeroUsize::new(2).unwrap();
 
+    let r = b.register(n);
+    let r = program!( &mut b, r;
+        not r;
+        h r[0];
+        control not r[0], r[1];
+        rz(2. * std::f64::consts::FRAC_PI_3) r[1];
+        h r;
+    )
+    .unwrap();
+    let (r, m_handle) = b.stochastic_measure(r);
+
+    // run and get probabilities
+    let (_, mut measured) = run_local::<f64>(&r).unwrap();
+    measured.pop_stochastic_measurements(m_handle).unwrap()
+}
+#[cfg(feature = "macros")]
+fn circuit3() -> Vec<f64> {
+    let mut b = LocalBuilder::<f64>::default();
+    let n = NonZeroUsize::new(2).unwrap();
+    let r = b.register(n);
+
+    let r = program!(&mut b, r;
+        not r;
+        h r[0];
+        control not r[0], r[1];
+        rz(std::f64::consts::FRAC_PI_3) r[0];
+        rz(2. * std::f64::consts::FRAC_PI_3) r[1];
+        h r;
+    )
+    .unwrap();
+    let (r, m_handle) = b.stochastic_measure(r);
+
+    // run and get probabilities
+    let (_, mut measured) = run_local::<f64>(&r).unwrap();
+    measured.pop_stochastic_measurements(m_handle).unwrap()
+}
 
 #[cfg(not(feature = "macros"))]
-fn main() {}
+fn main() -> () {}
 
+/// Bell inequality:
+/// |P(a, b) - P(a, c)| - P(b, c) <= 1
+/// To get P(a, b), P(a, c) and P(b, c) we use the 3 circuits presented in:
+/// https://arxiv.org/pdf/1712.05642.pdf - II.IMPLEMENTED EXPERIMENTS -> 3. Bell's inequality
+///
+/// A violation of the inequality is expected in any quantum computer or simulator.
+#[cfg(feature = "macros")]
+fn main() -> Result<(), CircuitError> {
+    println!("Bell inequality: |P(a, b) - P(a, c)| - P(b, c) <= 1");
+
+    let a_b = circuit1();
+    let p_of_a_b = (a_b[0] + a_b[3]) - (a_b[1] + a_b[2]);
+    println!("P(a, b) = {:.2}", p_of_a_b);
+
+    let a_c = circuit2();
+    let p_of_a_c = (a_c[0] + a_c[3]) - (a_c[1] + a_c[2]);
+    println!("P(a, c) = {:.2}", p_of_a_c);
+
+    let b_c = circuit3();
+    let p_of_b_c = (b_c[0] + b_c[3]) - (b_c[1] + b_c[2]);
+    println!("P(b, c) = {:.2}", p_of_b_c);
+
+    let left_side = num::abs(p_of_a_b - p_of_a_c) - p_of_b_c;
+    println!(
+        "|{:.2} - {:.2}| - ({:.2}) = {:.2} IS NOT <= 1",
+        p_of_a_b, p_of_a_c, p_of_b_c, left_side
+    );
+
+    assert!(left_side > 1.0);
+
+    Ok(())
+}

--- a/qip/examples/bell_inequalities.rs
+++ b/qip/examples/bell_inequalities.rs
@@ -1,0 +1,12 @@
+use qip::prelude::*;
+use std::num::NonZeroUsize;
+
+fn circuit1() -> Vec<f64> {
+
+    let mut b = LocalBuilder::<f64>::default();
+    let n = NonZeroUsize::new(2).unwrap();
+
+    let q = b.qubit();
+    let ra = b.register(n);
+    let r = program!() //Not sure what to use here
+}

--- a/qip/examples/cswap.rs
+++ b/qip/examples/cswap.rs
@@ -1,0 +1,31 @@
+use qip::prelude::*;
+use std::num::NonZeroUsize;
+
+
+fn main() -> Result<(), CircuitError> {
+
+    let mut b = LocalBuilder::<f64>::default();
+    let n = NonZeroUsize::new(3).unwrap();
+
+    let q = b.qubit();
+    let ra = b.register(n);
+    let rb = b.register(n);
+
+    let q = b.h(q);
+
+    let mut cb = b.condition_with(q);
+    let (ra, rb) = cb.swap(ra, rb).unwrap();
+    let q = cb.dissolve();
+
+    let q = b.h(q);
+
+    let (q, m_handle) = b.measure(q);
+
+
+    let (_, measured) = b.calculate_state_with_init([(&ra, 0b000), (&rb, 0b001)]);
+    let (result, p) = measured.get_measurement(m_handle);
+    println!("Measured: {:?} (with chance {:?})", result, p);
+
+    Ok(())
+
+}

--- a/qip/examples/cswap.rs
+++ b/qip/examples/cswap.rs
@@ -1,9 +1,7 @@
 use qip::prelude::*;
 use std::num::NonZeroUsize;
 
-
 fn main() -> Result<(), CircuitError> {
-
     let mut b = LocalBuilder::<f64>::default();
     let n = NonZeroUsize::new(3).unwrap();
 
@@ -21,11 +19,9 @@ fn main() -> Result<(), CircuitError> {
 
     let (q, m_handle) = b.measure(q);
 
-
     let (_, measured) = b.calculate_state_with_init([(&ra, 0b000), (&rb, 0b001)]);
     let (result, p) = measured.get_measurement(m_handle);
     println!("Measured: {:?} (with chance {:?})", result, p);
 
     Ok(())
-
 }

--- a/qip/examples/dense_coding.rs
+++ b/qip/examples/dense_coding.rs
@@ -1,0 +1,24 @@
+use qip::prelude::*;
+use std::num::NonZeroUsize;
+
+fn run_alice<P: Precision, CB: CircuitBuilder>(b: &mut LocalBuilder<P>, epr_alice: CB::Register , bit_a: bool, bit_b: bool) {
+
+    match (bit_a, bit_b) {
+        (false, false) => epr_alice,
+        (false, true) => b.x(epr_alice),
+        (true, false) => b.z(epr_alice),
+        (true, true) => b.y(epr_alice),
+
+    }
+
+}
+
+
+
+
+fn main() -> Result<(), CircuitError> {
+
+    let bits_a = vec![true, false, true, false];
+    let bits_b = vec![true, true, false, false];
+
+}

--- a/qip/examples/dense_coding.rs
+++ b/qip/examples/dense_coding.rs
@@ -1,6 +1,6 @@
+use qip::builder::Qudit;
 use qip::prelude::*;
 use std::num::NonZeroUsize;
-use qip::builder::Qudit;
 
 /// Encode the two classical bits Alice wants to communicate to Bob.
 ///
@@ -13,18 +13,19 @@ use qip::builder::Qudit;
 /// Returns Alice qubit with applied gate.
 ///
 /// https://en.wikipedia.org/wiki/Superdense_coding#Encoding
-fn run_alice<P: Precision, CB: CliffordTBuilder<P>>(b: &mut CB, epr_alice: CB::Register , bit_a: bool, bit_b: bool) -> CB::Register {
-
+fn run_alice<P: Precision, CB: CliffordTBuilder<P>>(
+    b: &mut CB,
+    epr_alice: CB::Register,
+    bit_a: bool,
+    bit_b: bool,
+) -> CB::Register {
     match (bit_a, bit_b) {
         (false, false) => epr_alice,
         (false, true) => b.x(epr_alice),
         (true, false) => b.z(epr_alice),
         (true, true) => b.y(epr_alice),
-
     }
-
 }
-
 
 /// Decode the message Alice transmitted to Bob.
 ///
@@ -45,13 +46,10 @@ fn run_bob<P: Precision>(b: &mut LocalBuilder<P>, r_alice: Qudit, epr_bob: Qudit
     let (r, m) = b.measure(r);
     let (_, measurements) = b.calculate_state();
     let (m, _) = measurements.get_measurement(m);
-    ((m & 2) == 2,  (m & 1) == 1)
-    
+    ((m & 2) == 2, (m & 1) == 1)
 }
 
-
 fn main() {
-
     let n = NonZeroUsize::new(1).unwrap();
     let bits_a = vec![true, false, true, false];
     let bits_b = vec![true, true, false, false];
@@ -68,7 +66,5 @@ fn main() {
             "Alice: ({:?},{:?}) \tBob: ({:?}, {:?})",
             bit_a, bit_b, bob_a, bob_b
         );
-
     }
-
 }

--- a/qip/examples/dense_coding.rs
+++ b/qip/examples/dense_coding.rs
@@ -1,7 +1,19 @@
 use qip::prelude::*;
 use std::num::NonZeroUsize;
+use qip::builder::Qudit;
 
-fn run_alice<P: Precision, CB: CircuitBuilder>(b: &mut LocalBuilder<P>, epr_alice: CB::Register , bit_a: bool, bit_b: bool) {
+/// Encode the two classical bits Alice wants to communicate to Bob.
+///
+/// Depending on the classical bits combination a different gate is applied:
+/// 00: Do nothing (or apply Identity gate)
+/// 01: Apply Pauli-X gate
+/// 10: Apply Pauli-Z gate
+/// 11: Apply Pauli-Y gate (or apply Pauli-Z gate followed by a Pauli-X gate)
+///
+/// Returns Alice qubit with applied gate.
+///
+/// https://en.wikipedia.org/wiki/Superdense_coding#Encoding
+fn run_alice<P: Precision, CB: CliffordTBuilder<P>>(b: &mut CB, epr_alice: CB::Register , bit_a: bool, bit_b: bool) -> CB::Register {
 
     match (bit_a, bit_b) {
         (false, false) => epr_alice,
@@ -12,6 +24,40 @@ fn run_alice<P: Precision, CB: CircuitBuilder>(b: &mut LocalBuilder<P>, epr_alic
     }
 
 }
+
+
+/// Decode the message Alice transmitted to Bob.
+///
+/// Bob applies the restoration operation on his qubit and the one transmitted
+/// by Alice to decode the original message. After restoration:
+/// |00>: 00
+/// |10>: 10
+/// |01>: 01
+/// |11>: 11
+///
+/// Returns a pair of classical bits.
+///
+/// https://en.wikipedia.org/wiki/Superdense_coding#Decoding
+fn run_bob<P: Precision>(b: &mut LocalBuilder<P>, r_alice: Qudit, epr_bob: Qudit) -> (bool, bool) {
+    let (r_alice, r_bob) = b.cnot(r_alice, epr_bob).unwrap();
+    let r_alice = b.h(r_alice);
+    let r = b.merge_two_registers(r_bob, r_alice);
+    let (r, m) = b.measure(r);
+    let (_, measurements) = b.calculate_state();
+    let (m, _) = measurements.get_measurement(m);
+    ((m & 2) == 2,  (m & 1) == 1)
+    
+}
+
+
+// let r = b.merge(vec![r_bob, r_alice]).unwrap();
+// let (r, m) = b.measure(r);
+
+// let (_, measurements) = run_local::<f64>(&r).unwrap();
+// let (m, _) = measurements.get_measurement(&m).unwrap();
+
+// ((m & 2) == 2, (m & 1) == 1)
+
 
 
 

--- a/qip/examples/dense_coding.rs
+++ b/qip/examples/dense_coding.rs
@@ -50,21 +50,25 @@ fn run_bob<P: Precision>(b: &mut LocalBuilder<P>, r_alice: Qudit, epr_bob: Qudit
 }
 
 
-// let r = b.merge(vec![r_bob, r_alice]).unwrap();
-// let (r, m) = b.measure(r);
+fn main() {
 
-// let (_, measurements) = run_local::<f64>(&r).unwrap();
-// let (m, _) = measurements.get_measurement(&m).unwrap();
-
-// ((m & 2) == 2, (m & 1) == 1)
-
-
-
-
-
-fn main() -> Result<(), CircuitError> {
-
+    let n = NonZeroUsize::new(1).unwrap();
     let bits_a = vec![true, false, true, false];
     let bits_b = vec![true, true, false, false];
+
+    for (bit_a, bit_b) in bits_a.into_iter().zip(bits_b.into_iter()) {
+        let mut b = LocalBuilder::<f64>::default();
+        let epr_alice = b.register(n);
+        let epr_bob = b.register(n);
+
+        let r_alice = run_alice(&mut b, epr_alice, bit_a, bit_b);
+        let (bob_a, bob_b) = run_bob(&mut b, r_alice, epr_bob);
+
+        println!(
+            "Alice: ({:?},{:?}) \tBob: ({:?}, {:?})",
+            bit_a, bit_b, bob_a, bob_b
+        );
+
+    }
 
 }


### PR DESCRIPTION
This is the first example with CSWAP. The new documentation was used (internally generated using `cargo doc --open`) and the layout of the [old examples](https://github.com/Renmusxd/RustQIP/blob/56757b5a3eb2474542aa8a47ff839470d98d4f91/examples/cswap.rs) as well

Ive started working on the dense_coding as well. However, I am faced with difficulty in using the `x, y, z` methods inside the match statements. For example I get this in the last three statements: 
```
mismatched types
      expected struct `Qudit`
found associated type `<CB as qip::builder_traits::CircuitBuilder>::Register
```