### PR TITLE
Implement Error for CircuitError

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 members = ["qip", "qip-macros", "qip-iterators"]
-
+resolver = "2"

--- a/qip/src/errors.rs
+++ b/qip/src/errors.rs
@@ -1,19 +1,32 @@
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
 /// An error from building the circuit.
 #[derive(Debug)]
-pub struct CircuitError {
-    /// The error message.
-    pub msg: String,
+pub enum CircuitError {
+    /// A generic error.
+    Generic(String),
 }
 
 impl CircuitError {
     /// Construct a new error.
     pub fn new<S>(msg: S) -> Self
-        where
-            S: Into<String>,
+    where
+        S: Into<String>,
     {
-        Self { msg: msg.into() }
+        Self::Generic(msg.into())
     }
 }
 
 /// A result which may contain a circuit error.
 pub type CircuitResult<T> = Result<T, CircuitError>;
+
+impl Error for CircuitError {}
+
+impl Display for CircuitError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Generic(msg) => write!(f, "{}", msg),
+        }
+    }
+}


### PR DESCRIPTION
This PR does three things:

- It changes the package resolver to version 2, unblocking restores on current cargo versions.
- It implements `Display` and `Error` for `CircuitError`, allowing it to be used like a regular error.
- It changes `CircuitError` from a `struct` to an `enum`, making it more extensible.