### PR TITLE
chore: apply cargo fmt, fix clippy warnings, and ensure tests pass

### DIFF
--- a/qip-iterators/benches/matmul_bench.rs
+++ b/qip-iterators/benches/matmul_bench.rs
@@ -10,11 +10,11 @@ mod tests {
     use faer_core::{Mat, Parallelism};
     use ndarray::linalg::{general_mat_vec_mul, Dot};
     use ndarray::{Array1, Array2, LinalgScalar};
+    use num_traits::{Num, One, Zero};
     use qip_iterators::iterators::MatrixOp;
     use qip_iterators::matrix_ops::{apply_op, apply_ops};
     use sprs::{kronecker_product, CsMat, TriMat};
     use test::Bencher;
-    use num_traits::{Num, One, Zero};
 
     #[bench]
     fn bench_ones_qip(b: &mut Bencher) {
@@ -75,8 +75,8 @@ mod tests {
     }
 
     fn make_ones_mat<P: LinalgScalar>(n: usize) -> Array2<P> {
-        let mut acc = Array2::from_shape_vec((2, 2), vec![P::one(); 4])
-            .expect("Could not make 2x2 matrix.");
+        let mut acc =
+            Array2::from_shape_vec((2, 2), vec![P::one(); 4]).expect("Could not make 2x2 matrix.");
         for _ in 1..n {
             acc = ndarray::linalg::kron(&acc, &Array2::eye(2));
         }
@@ -123,7 +123,6 @@ mod tests {
             )
         });
     }
-
 
     #[bench]
     fn bench_ones_faer_reuse_arena(b: &mut Bencher) {

--- a/qip-iterators/src/iterators/ops.rs
+++ b/qip-iterators/src/iterators/ops.rs
@@ -26,12 +26,10 @@ impl<P> MatrixOp<P> {
             MatrixOp::Matrix(indices, _) => indices.len(),
             MatrixOp::SparseMatrix(indices, _) => indices.len(),
             MatrixOp::Swap(a, b) => {
-                debug_assert_eq!(b.len(), a*2);
-                a*2
-            },
-            MatrixOp::Control(_, os, _) => {
-                os.len()
-            },
+                debug_assert_eq!(b.len(), a * 2);
+                a * 2
+            }
+            MatrixOp::Control(_, os, _) => os.len(),
         }
     }
 
@@ -161,9 +159,7 @@ impl<P> fmt::Debug for MatrixOp<P> {
         let (name, indices) = match self {
             MatrixOp::Matrix(indices, _) => ("Matrix".to_string(), indices.clone()),
             MatrixOp::SparseMatrix(indices, _) => ("SparseMatrix".to_string(), indices.clone()),
-            MatrixOp::Swap(_n, indices) => {
-                ("Swap".to_string(), indices.clone())
-            }
+            MatrixOp::Swap(_n, indices) => ("Swap".to_string(), indices.clone()),
             MatrixOp::Control(num_c_indices, indices, op) => {
                 let name = format!("C({:?})", *op);
                 (name, indices[..*num_c_indices].to_vec())

--- a/qip-iterators/src/iterators/qubit_iterators.rs
+++ b/qip-iterators/src/iterators/qubit_iterators.rs
@@ -20,7 +20,7 @@ where
 {
     /// Build a new iterator using the row index, the number of qubits in the matrix, and the
     /// complex values of the matrix.
-    pub fn new(row: usize, n: usize, data: &'a [P]) -> MatrixOpIterator<P> {
+    pub fn new(row: usize, n: usize, data: &'a [P]) -> MatrixOpIterator<'a, P> {
         let lower = get_flat_index(n, row, 0);
         let upper = get_flat_index(n, row, 1 << n);
         MatrixOpIterator {
@@ -70,7 +70,7 @@ where
     P: Clone,
 {
     /// Build a new iterator using the row index, and the sparse matrix data.
-    pub fn new(row: usize, data: &'a [Vec<(usize, P)>]) -> SparseMatrixOpIterator<P> {
+    pub fn new(row: usize, data: &'a [Vec<(usize, P)>]) -> SparseMatrixOpIterator<'a, P> {
         SparseMatrixOpIterator {
             data: &data[row],
             last_index: None,
@@ -207,7 +207,7 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.last_col.is_none() {
-            let lower_mask: usize = !(std::usize::MAX << self.half_n);
+            let lower_mask: usize = !(usize::MAX << self.half_n);
             let lower = self.row & lower_mask;
             let upper = self.row >> self.half_n;
             self.last_col = Some((lower << self.half_n) + upper);

--- a/qip-iterators/src/utils.rs
+++ b/qip-iterators/src/utils.rs
@@ -1,5 +1,3 @@
-use std::mem::size_of;
-
 /// Get the index into an Op matrix
 #[inline]
 pub fn get_flat_index(nindices: usize, i: usize, j: usize) -> usize {
@@ -20,7 +18,7 @@ pub fn get_flat_index(nindices: usize, i: usize, j: usize) -> usize {
 /// ```
 #[inline]
 pub fn flip_bits(n: usize, num: usize) -> usize {
-    let leading_zeros = 8 * size_of::<usize>() - n;
+    let leading_zeros = usize::BITS as usize - n;
     num.reverse_bits() >> leading_zeros
 }
 

--- a/qip/src/conditioning.rs
+++ b/qip/src/conditioning.rs
@@ -19,7 +19,7 @@ pub trait Conditionable: CircuitBuilder {
     ) -> Result<(Self::Register, Self::Register), CircuitError>;
 
     /// Construct a new circuitbuilder which conditions all unitaries with `cr`.
-    fn condition_with(&mut self, cr: Self::Register) -> Conditioned<Self> {
+    fn condition_with(&mut self, cr: Self::Register) -> Conditioned<'_, Self> {
         Conditioned::new(self, cr)
     }
 }

--- a/qip/src/state_ops/matrix_ops.rs
+++ b/qip/src/state_ops/matrix_ops.rs
@@ -111,7 +111,11 @@ pub fn make_control_op<P>(
         match op {
             MatrixOp::Control(num_oc_indices, oo_indices, op) => {
                 c_indices.extend(oo_indices);
-                Ok(MatrixOp::Control(num_c_indices + num_oc_indices, c_indices, op))
+                Ok(MatrixOp::Control(
+                    num_c_indices + num_oc_indices,
+                    c_indices,
+                    op,
+                ))
             }
             op => {
                 c_indices.extend(op.indices());
@@ -258,8 +262,8 @@ pub fn make_op_matrix<P: Precision>(n: usize, op: &MatrixOp<Complex<P>>) -> Vec<
 
 #[cfg(test)]
 mod state_ops_tests {
-    use qip_iterators::matrix_ops::get_index;
     use super::*;
+    use qip_iterators::matrix_ops::get_index;
 
     #[test]
     fn test_get_bit() {


### PR DESCRIPTION
This PR introduces codebase-wide cleanup and consistency improvements:
- Applied `cargo fmt` to enforce standardized code formatting.
- Fixed all `Clippy warnings` across the workspace, including lifetime syntax issues and deprecated patterns.
- Verified that all `unit tests` and `examples` run successfully.

> Note: Excluded `nightly-only benches` (`#![feature(test)]`) from CI since they require unstable features.

The following commands were run to validate the changes:
```bash
cargo fmt --all -- --check

RUSTFLAGS="-D warnings" cargo clippy --workspace --all-features --bins --examples --tests -- -Dwarnings

RUSTFLAGS="-D warnings" cargo test --workspace --all-features --lib --bins --examples --tests
```

> Impact: These changes are non-functional and focus solely on formatting, lint cleanup, and ensuring a clean test suite. They improve maintainability and prepare the codebase for future contributions.